### PR TITLE
chore: remove invalid bypass actor

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -42,9 +42,6 @@ rulesets:
     target: branch
     enforcement: active
     bypass_actors:
-      - actor_type: OrganizationAdmin
-        actor_id: 1
-        bypass_mode: always
       - actor_type: RepositoryRole
         actor_id: 5
         bypass_mode: always


### PR DESCRIPTION
This commit removes the `OrganizationAdmin` as a bypass actor when
using GitHub Rulesets because it is not valid for users on GitHub
individual plans.

Idempotency-Key: d25904ba8eb877c7d7d494e71fc97e6ccbb693664a4ce2fc015a94a5df74b62d
