### PR TITLE
ci: temp pin KLC to v8 branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,9 @@ jobs:
           python-version: "3.12.1"
 
       - name: Set up KLC Check
+        # FIXME: Temporarily pinned to v8 to pass tests
         run: |
-          git clone --depth 1 https://gitlab.com/kicad/libraries/kicad-library-utils /opt/kicad-library-utils
+          git clone --depth 1 --branch v8 https://gitlab.com/kicad/libraries/kicad-library-utils /opt/kicad-library-utils
           /opt/kicad-library-utils/klc-check/check_symbol.py --help
           /opt/kicad-library-utils/klc-check/check_footprint.py --help
 


### PR DESCRIPTION
This commit temporarily pins the KiCad Library Convention check to the `v8` branch until they are migrated to `v9`.