### PR TITLE
ci: bump to ubuntu-24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ defaults:
 
 jobs:
   test-symbols:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 3
 
     steps:
@@ -34,7 +34,7 @@ jobs:
           klc-symbol -vv --footprints ./lib/footprints/ ./lib/symbols/_Custom.kicad_sym || [ "${?}" -eq 2 ]
 
   test-footprints:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 3
 
     steps:

--- a/.github/workflows/deps-automerge.yml
+++ b/.github/workflows/deps-automerge.yml
@@ -18,7 +18,7 @@ defaults:
 
 jobs:
   automerge:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 2
     if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' && github.repository_owner == 'loozhengyuan' }}
 


### PR DESCRIPTION
This commit updates the repositories to use `ubuntu-24.04` runner type.

Idempotency-Key: b65e24792f1426145cd7e87ec4b34af8f1f8997b122f0173c1f5dc88a97e9c97
