### PR TITLE
fix: JST PA inconsistent silkscreen

### DIFF
--- a/lib/footprints/_Custom.pretty/JST_PA_SM05B-PASS_1x05_P2.00mm_Horizontal.kicad_mod
+++ b/lib/footprints/_Custom.pretty/JST_PA_SM05B-PASS_1x05_P2.00mm_Horizontal.kicad_mod
@@ -117,7 +117,7 @@
 		(uuid "084dee76-d6ac-45a1-9f0f-db38059764c2")
 	)
 	(fp_line
-		(start 7.1 4.05)
+		(start 7.1 3.9)
 		(end 7.1 1.8)
 		(stroke
 			(width 0.12)


### PR DESCRIPTION
This commit fixes an issue with the JST PA SM05B-PASS footprint where one side of the silkscreen line is unintentionally longer than the other.